### PR TITLE
Type safety: strict_types, final class, return types, private state (roadmap #3)

### DIFF
--- a/src/Inflect.php
+++ b/src/Inflect.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Inflect;
 
-class Inflect
+final class Inflect
 {
-    static $plural = array(
+    private static array $plural = [
         '/(quiz)$/i'               => "$1zes",
         '/^(oxen)$/i'              => "$1",
         '/^(ox)$/i'                => "$1en",
@@ -19,7 +21,7 @@ class Inflect
         '/sis$/i'                  => "ses",
         '/([ti])a$/i'              => "$1a",
         '/([ti])um$/i'             => "$1a",
-        '/(buffal|tomat|potat|ech|her|vet)o$/i'=> "$1oes",
+        '/(buffal|tomat|potat|ech|her|vet)o$/i' => "$1oes",
         '/(bu)s$/i'                => "$1ses",
         '/(alias|status)$/i'       => "$1es",
         '/(octop|vir)i$/i'         => "$1i",
@@ -27,10 +29,10 @@ class Inflect
         '/(ax|test)is$/i'          => "$1es",
         '/(us)$/i'                 => "$1es",
         '/s$/i'                    => "s",
-        '/$/'                      => "s"
-    );
+        '/$/'                      => "s",
+    ];
 
-    static $singular = array(
+    private static array $singular = [
         '/(ss)$/i'                  => "$1",
         '/(database)s$/i'           => "$1",
         '/(quiz)zes$/i'             => "$1",
@@ -64,10 +66,10 @@ class Inflect
         '/(h|bl)ouses$/i'           => "$1ouse",
         '/(corpse)s$/i'             => "$1",
         '/(use)s$/i'                => "$1",
-        '/s$/i'                     => ""
-    );
+        '/s$/i'                     => "",
+    ];
 
-    static $irregular = array(
+    private static array $irregular = [
         'zombie'     => 'zombies',
         'move'       => 'moves',
         'foot'       => 'feet',
@@ -85,10 +87,10 @@ class Inflect
         'syllabus'   => 'syllabi',
         'curriculum' => 'curricula',
         'medium'     => 'media',
-        'bacterium'  => 'bacteria'
-    );
+        'bacterium'  => 'bacteria',
+    ];
 
-    static $uncountable = array(
+    private static array $uncountable = [
         'sheep'       => true,
         'fish'        => true,
         'deer'        => true,
@@ -109,104 +111,91 @@ class Inflect
         'traffic'     => true,
         'furniture'   => true,
         'metadata'    => true,
-        'multimedia'  => true
-    );
+        'multimedia'  => true,
+    ];
 
-    private static $pluralCache = array();
-    private static $singularCache = array();
+    private static array $pluralCache = [];
+    private static array $singularCache = [];
 
-    public static function pluralize($string)
+    public static function pluralize(string $string): string
     {
-        if (!$string)
-            return;
+        if ($string === '') {
+            return '';
+        }
 
-        if (!isset(self::$pluralCache[$string]))
-        {
+        if (!isset(self::$pluralCache[$string])) {
             // save some time in the case that singular and plural are the same
-            if (isset(self::$uncountable[strtolower($string)]))
-            {
+            if (isset(self::$uncountable[strtolower($string)])) {
                 self::$pluralCache[$string] = $string;
                 return $string;
             }
 
             // already a known irregular plural — leave it alone (e.g. "people", "men")
-            foreach (self::$irregular as $plural)
-            {
-                if (strcasecmp($string, $plural) === 0)
-                {
+            foreach (self::$irregular as $plural) {
+                if (strcasecmp($string, $plural) === 0) {
                     self::$pluralCache[$string] = $string;
                     return $string;
                 }
             }
 
             // check for irregular singular forms
-            foreach (self::$irregular as $pattern => $result)
-            {
+            foreach (self::$irregular as $pattern => $result) {
                 $pattern = '/' . $pattern . '$/i';
 
-                if (preg_match($pattern, $string))
-                {
+                if (preg_match($pattern, $string)) {
                     self::$pluralCache[$string] = self::preserveFirstCase($string, preg_replace($pattern, $result, $string));
                     return self::$pluralCache[$string];
                 }
             }
 
             // check for matches using regular expressions
-            foreach (self::$plural as $pattern => $result)
-            {
-                if (preg_match($pattern, $string))
-                {
-                    self::$pluralCache[$string] = $result = preg_replace($pattern, $result, $string);
+            foreach (self::$plural as $pattern => $result) {
+                if (preg_match($pattern, $string)) {
+                    self::$pluralCache[$string] = preg_replace($pattern, $result, $string);
                     return self::$pluralCache[$string];
                 }
             }
 
             self::$pluralCache[$string] = $string;
         }
+
         return self::$pluralCache[$string];
     }
 
-    public static function singularize($string)
+    public static function singularize(string $string): string
     {
-        if (!$string)
-            return;
+        if ($string === '') {
+            return '';
+        }
 
-        if (!isset(self::$singularCache[$string]))
-        {
+        if (!isset(self::$singularCache[$string])) {
             // save some time in the case that singular and plural are the same
-            if (isset(self::$uncountable[strtolower($string)]))
-            {
+            if (isset(self::$uncountable[strtolower($string)])) {
                 self::$singularCache[$string] = $string;
                 return $string;
             }
 
             // already a known irregular singular — leave it alone (e.g. "datum", "criterion")
-            foreach (self::$irregular as $singular => $_plural)
-            {
-                if (strcasecmp($string, $singular) === 0)
-                {
+            foreach (self::$irregular as $singular => $_plural) {
+                if (strcasecmp($string, $singular) === 0) {
                     self::$singularCache[$string] = $string;
                     return $string;
                 }
             }
 
             // check for irregular plural forms
-            foreach (self::$irregular as $result => $pattern)
-            {
+            foreach (self::$irregular as $result => $pattern) {
                 $pattern = '/' . $pattern . '$/i';
 
-                if (preg_match($pattern, $string))
-                {
+                if (preg_match($pattern, $string)) {
                     self::$singularCache[$string] = self::preserveFirstCase($string, preg_replace($pattern, $result, $string));
                     return self::$singularCache[$string];
                 }
             }
 
             // check for matches using regular expressions
-            foreach (self::$singular as $pattern => $result)
-            {
-                if (preg_match($pattern, $string))
-                {
+            foreach (self::$singular as $pattern => $result) {
+                if (preg_match($pattern, $string)) {
                     self::$singularCache[$string] = preg_replace($pattern, $result, $string);
                     return self::$singularCache[$string];
                 }
@@ -218,21 +207,21 @@ class Inflect
         return self::$singularCache[$string];
     }
 
-    private static function preserveFirstCase($source, $replaced)
+    public static function pluralizeIf(int $count, string $string): string
     {
-        if ($source !== '' && $replaced !== '' && ctype_upper($source[0]) && ctype_lower($replaced[0]))
-        {
+        if ($count === 1) {
+            return "1 $string";
+        }
+
+        return "$count " . self::pluralize($string);
+    }
+
+    private static function preserveFirstCase(string $source, string $replaced): string
+    {
+        if ($source !== '' && $replaced !== '' && ctype_upper($source[0]) && ctype_lower($replaced[0])) {
             return ucfirst($replaced);
         }
+
         return $replaced;
     }
-
-    public static function pluralizeIf($count, $string)
-    {
-        if ($count == 1)
-            return "1 $string";
-        else
-            return "$count " . self::pluralize($string);
-    }
 }
-

--- a/tests/InflectTest.php
+++ b/tests/InflectTest.php
@@ -22,6 +22,31 @@ final class InflectTest extends TestCase
         $this->assertSame($expected, Inflect::pluralize($input));
     }
 
+    public function testEmptyStringReturnsEmptyString(): void
+    {
+        $this->assertSame('', Inflect::pluralize(''));
+        $this->assertSame('', Inflect::singularize(''));
+    }
+
+    #[DataProvider('pluralizeIfProvider')]
+    public function testPluralizeIf(int $count, string $noun, string $expected): void
+    {
+        $this->assertSame($expected, Inflect::pluralizeIf($count, $noun));
+    }
+
+    public static function pluralizeIfProvider(): array
+    {
+        return [
+            [1, 'cat', '1 cat'],
+            [2, 'cat', '2 cats'],
+            [0, 'cat', '0 cats'],
+            [1, 'person', '1 person'],
+            [3, 'person', '3 people'],
+            [0, 'person', '0 people'],
+            [5, 'datum', '5 data'],
+        ];
+    }
+
     public static function singularizeProvider(): array
     {
         return [


### PR DESCRIPTION
Addresses ROADMAP.md item #3. Stacked on #13 (which is stacked on #12).

## Changes
- **`declare(strict_types=1)`** at the top of the class.
- **`final class Inflect`** — the class was never designed for inheritance; locale support (roadmap §5a) will plug in via composition.
- **Param and return types**:
  - `pluralize(string $string): string`
  - `singularize(string $string): string`
  - `pluralizeIf(int $count, string $string): string`
  - `preserveFirstCase(string $source, string $replaced): string`
- **Private static state** — the rule tables (`$plural`, `$singular`, `$irregular`, `$uncountable`) and memoization caches are now `private`. The extensibility API (roadmap §5) will own the supported ways to add rules.
- **Typed properties** on all static arrays (PHP 7.4+ syntax).
- **Short array syntax** throughout (`[]` instead of `array()`).
- **`==` → `===`** in `pluralizeIf` count check.

## Nullable input decision
Current behavior: `pluralize(null)` silently returned `null` via the falsy-truthy check at the top; `pluralize('')` did the same.

New behavior:
- `pluralize(null)` / `singularize(null)` → **`TypeError`**. Callers with `null` are now forced to handle it explicitly.
- `pluralize('')` / `singularize('')` → returns `''`. No behavior surprise for empty-string inputs.

This is a breaking change for callers relying on the silent-null behavior — acceptable for the v2.0 major bump.

## Test plan
- [x] Added explicit empty-string coverage for `pluralize` and `singularize`.
- [x] Added a data-provider set for `pluralizeIf` including the zero case and irregulars (`person → people`, `datum → data`).
- [x] **117 tests / 118 assertions pass** on PHP 8.1 and 8.3.
- [ ] CI from #13 should run green on 8.1–8.4 once this PR rebases onto a merged base.

## Stacking
This closes the v2.0 trio: #12 (PHP baseline) → #13 (GitHub Actions CI) → #14 (this). Suggest merging in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)