### PR TITLE
Roadmap: engine/data package-split option for §5a (Path A now, Path B later)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,27 +39,52 @@ Largely shipped in #9 / #10. Remaining items:
 
 First-class support for multiple languages, not just English. All current rules (`$plural`, `$singular`, `$irregular`, `$uncountable`) are hard-coded English — the API should let a caller pick a locale at construction time and load the matching rule set.
 
-Prior exploration lives on the `feature/inflections` branch (WIP from 2014-ish). It sketched:
+### Prior art in this account
 
-- A constructor `new Inflect($locale = 'en')` alongside the existing static API.
-- A `src/Inflections/En.php` class holding the English rules as `protected static` arrays.
-- Moving `Inflect` up from `src/Inflect/Inflect.php` to `src/Inflect.php` (PSR-4 layout change).
+Two places in `mmucklo/*` have already reached for this design:
 
-That branch is incomplete (tests were dropped, ROADMAP not yet present) and predates the correctness fixes now on `master`. Use it as design reference, not as a merge base.
+- **`mmucklo/inflect@feature/inflections`** (WIP, ~2014). Sketched `new Inflect($locale = 'en')`, a `src/Inflections/En.php` class holding rules as `protected static` arrays, and a PSR-4 layout change. Incomplete — tests were dropped and the branch predates all correctness fixes now on `master`. Design reference only, not a merge base.
+- **`mmucklo/inflections`** (separate repo, last touched 2017-06-13). Purpose-built as a rule-data package for inflectors. Layout is `src/En/Plural.php`, `src/En/Singular.php`, `src/En/Uninflected.php`, each class exposing `public static $rules`, `$uninflected`, `$irregular`, and a `$version` stub. Rule set is substantially richer than what `inflect` currently carries, sourced from Doctrine Inflector + Rails. Stale and in need of modernization (PHP 5.6, PHPUnit 5.7, Travis) but the architecture is exactly the engine/data split this roadmap is moving toward.
 
-Concrete deliverables:
+### Two paths
+
+**Path A — vendor the rule data into `inflect`.** Introduce `src/Inflections/En.php` inside this repo, implementing a `Locale` contract. Simpler: one repo, one release cadence, no external dependency. Loses the package-boundary benefits but keeps everything local while locale support is young.
+
+**Path B — revive `mmucklo/inflections` as a sibling package.** Modernize that repo (PHP 8.1+, PHPUnit 10, GH Actions, private-or-read-only state), define a `Locale` contract it implements, and have `inflect` require it. This is the architecturally right answer:
+
+- Rule data and engine version independently — a new irregular in English doesn't force an engine release, and an engine bugfix doesn't republish rule data.
+- Third-party locale packages don't need to land in this repo. `someone/inflections-pl` implementing the `Locale` contract works out of the box.
+- Rule data becomes reusable by other PHP inflectors (Doctrine, Symfony String port, etc. — today each duplicates the same lists).
+- Cleaner test boundary: rule-data tests prove regexes are well-formed; engine tests prove inflection outcomes.
+
+The cost is real: two CI pipelines, two changelogs, two Packagist pages, two Dependabot surfaces. Worth paying only if third-party locale packages actually materialize.
+
+### Recommendation
+
+Path A for v2.2 (ship faster, one repo to reason about). Re-evaluate the split for v3.x once there's evidence of external locale demand. Keep the internal `Locale` contract clean enough that moving from A to B later is a file relocation, not a rewrite.
+
+### Concrete deliverables (Path A, v2.2)
 
 - Introduce a `Locale` / `Inflections` contract (plural rules, singular rules, irregulars, uncountables).
-- Ship `En` as the built-in implementation; keep the static `Inflect::pluralize()` / `Inflect::singularize()` delegating to `En` for backwards compatibility.
+- Ship `Inflect\Inflections\En` as the built-in implementation, seeded from the richer rule set in `mmucklo/inflections/En` rather than the minimal one currently in `Inflect`.
+- Keep the static `Inflect::pluralize()` / `Inflect::singularize()` delegating to `En` for backwards compatibility.
 - Add an instance API (`new Inflect('en')`, `$inflect->pluralize(...)`) so callers can pick a locale without touching globals.
 - Add at least one additional locale as proof of concept — candidates: `Es` (Spanish), `Fr` (French), `De` (German). Each has distinct pluralization patterns (e.g. Spanish `-es` vs `-s` depending on final consonant, French silent-consonant rules, German umlaut + plural suffix classes).
-- Document how to register a third-party locale package (fits with the extensibility APIs in §5).
+- Document how to register a third-party locale (fits with the extensibility APIs in §5).
 
-Open design questions to resolve before implementation:
+### Deferred to Path B (v3.x, conditional)
+
+- Extract `Inflect\Inflections\*` into `mmucklo/inflections` (modernized) and add it as a `composer require` of `inflect`.
+- Drop the bundled locales from `inflect` (or keep `En` as a fallback only).
+- Publish the `Locale` contract as a PHP interface that sibling packages can implement.
+- Trigger: either (a) a third party asks to publish a locale, (b) rule data starts changing on a cadence that diverges from engine releases, or (c) another inflector library expresses interest in consuming the rule data.
+
+### Open design questions to resolve before implementing Path A
 
 - Should locale resolution be lazy (load rule class on first call) or eager?
-- How should the static API choose a default locale — class constant, env var, or setter? The branch's `new Inflect($locale = 'en')` signature only addresses the instance case.
+- How should the static API choose a default locale — class constant, env var, or setter? The `feature/inflections` constructor `new Inflect($locale = 'en')` only addresses the instance case.
 - Does per-locale caching share a namespace, or is each locale's cache isolated?
+- Should the rule-table properties on `En` be `private` (matches the §3 tightening in `Inflect`) or `public` (matches the `mmucklo/inflections` convention, designed for external extension)? Leaning `private` with explicit extension APIs per §5.
 
 ## 6. Documentation
 


### PR DESCRIPTION
## Summary
Expands ROADMAP §5a with the option to eventually decouple rule data from the engine:

- **Path A — vendor into `inflect`** (v2.2): locale rule classes live in this repo behind a \`Locale\` contract.
- **Path B — sibling package** (v3.x, conditional): revive the existing \`mmucklo/inflections\` repo (stale since 2017, but architecturally aligned) as the rule-data package, have \`inflect\` depend on it.

## Why Path B matters
- Rule data and engine version independently.
- Third-party locale packages (\`someone/inflections-pl\`) work without landing in this repo.
- Rule data becomes reusable by other PHP inflectors (today Doctrine, Symfony String port, etc. each duplicate the same lists).
- Cleaner test boundary: rule-data tests verify regex validity; engine tests verify inflection outcomes.

## Why not Path B now
- Doubles the shipping surface (two CI pipelines, two changelogs, two Packagist pages, two Dependabot surfaces).
- Benefit is real only if third-party locale packages actually show up.
- \`mmucklo/inflections\` needs its own modernization pass before it can be a dep of a PHP 8.1+ library.

## Recommendation in the roadmap
Path A for v2.2. Keep the internal \`Locale\` contract clean enough that moving to B later is a file relocation, not a rewrite. Explicit triggers for when to switch to B:
1. A third party asks to publish a locale.
2. Rule data starts changing on a cadence that diverges from engine releases.
3. Another inflector library expresses interest in consuming the rule data.

Also noted: `mmucklo/inflections/En` has a substantially richer rule set than what \`inflect\` currently bundles — the \`En\` locale in Path A should be seeded from there, not the minimal set currently in \`Inflect\`.

## Test plan
- [ ] Confirm the A/B framing captures the tradeoff correctly.
- [ ] Confirm the Path B triggers are the right signals.
- [ ] Confirm v2.2 (Path A) / v3.x (Path B) phasing is the right split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)