### PR TITLE
CI: install ocular via Composer (fixes Scrutinizer coverage upload)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,11 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Install ocular
+        if: matrix.php == '8.3'
+        run: composer global require scrutinizer/ocular --no-interaction --no-progress
+
       - name: Upload coverage to Scrutinizer
         if: matrix.php == '8.3'
         continue-on-error: true
-        run: |
-          wget -q https://scrutinizer-ci.com/ocular.phar
-          php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+        run: $(composer global config bin-dir --absolute --quiet)/ocular code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
## Problem
\`scrutinizer-ci.com/ocular.phar\` now returns **HTTP 403 (Cloudflare bot challenge)**. The CI step that did \`wget -q https://scrutinizer-ci.com/ocular.phar\` was silently exiting with code 8.

Because the step was marked \`continue-on-error: true\`, GitHub Actions stayed green — but Scrutinizer never received coverage and every inspection sat **pending** until the 900s \`external_code_coverage\` timeout fired.

## Fix
Install \`scrutinizer/ocular\` (1.9) from Packagist via \`composer global require\` instead of wget-ing the phar. Resolves the binary path via \`composer global config bin-dir --absolute\` so it survives any future Composer default-path changes.

\`continue-on-error: true\` is preserved on the upload step — Scrutinizer outages shouldn't fail CI.

## Test plan
- [x] YAML validates.
- [ ] Confirm on PR run: ocular installs, uploads coverage, Scrutinizer inspection completes.
- [ ] Confirm master build turns green after merge (all four GH Actions legs + Codecov + Scrutinizer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)