### PR TITLE
Add PHPStan level 8 + PHP-CS-Fixer; fix surfaced issues (roadmap §7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Run PHPUnit
         run: vendor/bin/phpunit --coverage-clover=coverage.clover
 
+      - name: Run PHPStan
+        if: matrix.php == '8.3'
+        run: vendor/bin/phpstan analyse --no-progress --error-format=github
+
+      - name: Run PHP-CS-Fixer
+        if: matrix.php == '8.3'
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff
+
       - name: Upload coverage to Codecov
         if: matrix.php == '8.3'
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 vendor/*
 .phpunit.result.cache
 .phpunit.cache/
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/tests');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR12' => true,
+        'declare_strict_types' => true,
+        'no_unused_imports' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'single_quote' => true,
+        'trailing_comma_in_multiline' => true,
+    ])
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
         "php": ">=8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^10.5",
+        "phpstan/phpstan": "^2.1",
+        "friendsofphp/php-cs-fixer": "^3.95"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+  level: 8
+  paths:
+    - src
+    - tests

--- a/src/Inflect.php
+++ b/src/Inflect.php
@@ -6,69 +6,72 @@ namespace Inflect;
 
 final class Inflect
 {
+    /** @var array<string, string> */
     private static array $plural = [
-        '/(quiz)$/i'               => "$1zes",
-        '/^(oxen)$/i'              => "$1",
-        '/^(ox)$/i'                => "$1en",
-        '/([m|l])ice$/i'           => "$1ice",
-        '/([m|l])ouse$/i'          => "$1ice",
-        '/(matr|vert|ind)ix|ex$/i' => "$1ices",
-        '/(x|ch|ss|sh)$/i'         => "$1es",
-        '/([^aeiouy]|qu)y$/i'      => "$1ies",
-        '/(hive)$/i'               => "$1s",
-        '/(?:([^f])fe|([lr])f)$/i' => "$1$2ves",
-        '/(shea|lea|loa|thie)f$/i' => "$1ves",
-        '/sis$/i'                  => "ses",
-        '/([ti])a$/i'              => "$1a",
-        '/([ti])um$/i'             => "$1a",
-        '/(buffal|tomat|potat|ech|her|vet)o$/i' => "$1oes",
-        '/(bu)s$/i'                => "$1ses",
-        '/(alias|status)$/i'       => "$1es",
-        '/(octop|vir)i$/i'         => "$1i",
-        '/(octop|vir)us$/i'        => "$1i",
-        '/(ax|test)is$/i'          => "$1es",
-        '/(us)$/i'                 => "$1es",
-        '/s$/i'                    => "s",
-        '/$/'                      => "s",
+        '/(quiz)$/i'               => '$1zes',
+        '/^(oxen)$/i'              => '$1',
+        '/^(ox)$/i'                => '$1en',
+        '/([m|l])ice$/i'           => '$1ice',
+        '/([m|l])ouse$/i'          => '$1ice',
+        '/(matr|vert|ind)ix|ex$/i' => '$1ices',
+        '/(x|ch|ss|sh)$/i'         => '$1es',
+        '/([^aeiouy]|qu)y$/i'      => '$1ies',
+        '/(hive)$/i'               => '$1s',
+        '/(?:([^f])fe|([lr])f)$/i' => '$1$2ves',
+        '/(shea|lea|loa|thie)f$/i' => '$1ves',
+        '/sis$/i'                  => 'ses',
+        '/([ti])a$/i'              => '$1a',
+        '/([ti])um$/i'             => '$1a',
+        '/(buffal|tomat|potat|ech|her|vet)o$/i' => '$1oes',
+        '/(bu)s$/i'                => '$1ses',
+        '/(alias|status)$/i'       => '$1es',
+        '/(octop|vir)i$/i'         => '$1i',
+        '/(octop|vir)us$/i'        => '$1i',
+        '/(ax|test)is$/i'          => '$1es',
+        '/(us)$/i'                 => '$1es',
+        '/s$/i'                    => 's',
+        '/$/'                      => 's',
     ];
 
+    /** @var array<string, string> */
     private static array $singular = [
-        '/(ss)$/i'                  => "$1",
-        '/(database)s$/i'           => "$1",
-        '/(quiz)zes$/i'             => "$1",
-        '/(matr)ices$/i'            => "$1ix",
-        '/(vert|ind)ices$/i'        => "$1ex",
-        '/^(ox)en$/i'               => "$1",
-        '/(alias|status)(es)?$/i'   => "$1",
-        '/(octop|vir)i$/i'          => "$1us",
-        '/^(a)x[ie]s$/i'            => "$1xis",
-        '/(cris|ax|test)es$/i'      => "$1is",
-        '/(cris|ax|test)is$/i'      => "$1is",
-        '/(shoe|foe)s$/i'           => "$1",
-        '/(bus)es$/i'               => "$1",
-        '/^(toe)s$/i'               => "$1",
-        '/(o)es$/i'                 => "$1",
-        '/([m|l])ice$/i'            => "$1ouse",
-        '/(x|ch|ss|sh)es$/i'        => "$1",
-        '/(m)ovies$/i'              => "$1ovie",
-        '/(s)eries$/i'              => "$1eries",
-        '/([^aeiouy]|qu)ies$/i'     => "$1y",
-        '/([lr])ves$/i'             => "$1f",
-        '/(tive)s$/i'               => "$1",
-        '/(hive)s$/i'               => "$1",
-        '/(li|wi|kni)ves$/i'        => "$1fe",
-        '/([^f])ves$/i'             => "$1fe",
-        '/(shea|loa|lea|thie)ves$/i'=> "$1f",
-        '/(^analy)(sis|ses)$/i'     => "$1sis",
-        '/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i'  => "$1$2sis",
-        '/([ti])a$/i'               => "$1um",
-        '/(n)ews$/i'                => "$1ews",
-        '/(h|bl)ouses$/i'           => "$1ouse",
-        '/(corpse)s$/i'             => "$1",
-        '/(use)s$/i'                => "$1",
-        '/s$/i'                     => "",
+        '/(ss)$/i'                  => '$1',
+        '/(database)s$/i'           => '$1',
+        '/(quiz)zes$/i'             => '$1',
+        '/(matr)ices$/i'            => '$1ix',
+        '/(vert|ind)ices$/i'        => '$1ex',
+        '/^(ox)en$/i'               => '$1',
+        '/(alias|status)(es)?$/i'   => '$1',
+        '/(octop|vir)i$/i'          => '$1us',
+        '/^(a)x[ie]s$/i'            => '$1xis',
+        '/(cris|ax|test)es$/i'      => '$1is',
+        '/(cris|ax|test)is$/i'      => '$1is',
+        '/(shoe|foe)s$/i'           => '$1',
+        '/(bus)es$/i'               => '$1',
+        '/^(toe)s$/i'               => '$1',
+        '/(o)es$/i'                 => '$1',
+        '/([m|l])ice$/i'            => '$1ouse',
+        '/(x|ch|ss|sh)es$/i'        => '$1',
+        '/(m)ovies$/i'              => '$1ovie',
+        '/(s)eries$/i'              => '$1eries',
+        '/([^aeiouy]|qu)ies$/i'     => '$1y',
+        '/([lr])ves$/i'             => '$1f',
+        '/(tive)s$/i'               => '$1',
+        '/(hive)s$/i'               => '$1',
+        '/(li|wi|kni)ves$/i'        => '$1fe',
+        '/([^f])ves$/i'             => '$1fe',
+        '/(shea|loa|lea|thie)ves$/i' => '$1f',
+        '/(^analy)(sis|ses)$/i'     => '$1sis',
+        '/((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$/i'  => '$1$2sis',
+        '/([ti])a$/i'               => '$1um',
+        '/(n)ews$/i'                => '$1ews',
+        '/(h|bl)ouses$/i'           => '$1ouse',
+        '/(corpse)s$/i'             => '$1',
+        '/(use)s$/i'                => '$1',
+        '/s$/i'                     => '',
     ];
 
+    /** @var array<string, string> */
     private static array $irregular = [
         'zombie'     => 'zombies',
         'move'       => 'moves',
@@ -90,6 +93,7 @@ final class Inflect
         'bacterium'  => 'bacteria',
     ];
 
+    /** @var array<string, true> */
     private static array $uncountable = [
         'sheep'       => true,
         'fish'        => true,
@@ -114,7 +118,10 @@ final class Inflect
         'multimedia'  => true,
     ];
 
+    /** @var array<string, string> */
     private static array $pluralCache = [];
+
+    /** @var array<string, string> */
     private static array $singularCache = [];
 
     public static function pluralize(string $string): string
@@ -143,7 +150,7 @@ final class Inflect
                 $pattern = '/' . $pattern . '$/i';
 
                 if (preg_match($pattern, $string)) {
-                    self::$pluralCache[$string] = self::preserveFirstCase($string, preg_replace($pattern, $result, $string));
+                    self::$pluralCache[$string] = self::preserveFirstCase($string, preg_replace($pattern, $result, $string) ?? $string);
                     return self::$pluralCache[$string];
                 }
             }
@@ -151,7 +158,7 @@ final class Inflect
             // check for matches using regular expressions
             foreach (self::$plural as $pattern => $result) {
                 if (preg_match($pattern, $string)) {
-                    self::$pluralCache[$string] = preg_replace($pattern, $result, $string);
+                    self::$pluralCache[$string] = preg_replace($pattern, $result, $string) ?? $string;
                     return self::$pluralCache[$string];
                 }
             }
@@ -188,7 +195,7 @@ final class Inflect
                 $pattern = '/' . $pattern . '$/i';
 
                 if (preg_match($pattern, $string)) {
-                    self::$singularCache[$string] = self::preserveFirstCase($string, preg_replace($pattern, $result, $string));
+                    self::$singularCache[$string] = self::preserveFirstCase($string, preg_replace($pattern, $result, $string) ?? $string);
                     return self::$singularCache[$string];
                 }
             }
@@ -196,7 +203,7 @@ final class Inflect
             // check for matches using regular expressions
             foreach (self::$singular as $pattern => $result) {
                 if (preg_match($pattern, $string)) {
-                    self::$singularCache[$string] = preg_replace($pattern, $result, $string);
+                    self::$singularCache[$string] = preg_replace($pattern, $result, $string) ?? $string;
                     return self::$singularCache[$string];
                 }
             }

--- a/tests/InflectTest.php
+++ b/tests/InflectTest.php
@@ -34,6 +34,9 @@ final class InflectTest extends TestCase
         $this->assertSame($expected, Inflect::pluralizeIf($count, $noun));
     }
 
+    /**
+     * @return array<int, array{int, string, string}>
+     */
     public static function pluralizeIfProvider(): array
     {
         return [
@@ -47,6 +50,9 @@ final class InflectTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<int, array{string, string}>
+     */
     public static function singularizeProvider(): array
     {
         return [
@@ -116,6 +122,9 @@ final class InflectTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<int, array{string, string}>
+     */
     public static function pluralizeProvider(): array
     {
         return [


### PR DESCRIPTION
Addresses ROADMAP §7 (first pass — phpstan + cs-fixer).

## Tooling added
- **phpstan/phpstan ^2.1** as dev dep. Config at \`phpstan.neon.dist\`: **level 8**, scans \`src/\` and \`tests/\`.
- **friendsofphp/php-cs-fixer ^3.95** as dev dep. Config at \`.php-cs-fixer.dist.php\`:
  - \`@PSR12\`
  - \`declare_strict_types\`
  - \`no_unused_imports\`
  - \`ordered_imports\`
  - \`single_quote\`
  - \`trailing_comma_in_multiline\`
- Both wired into \`.github/workflows/ci.yml\` on the PHP 8.3 matrix leg. phpstan uses \`--error-format=github\` for inline PR annotations. cs-fixer runs \`--dry-run --diff\`.
- \`.gitignore\`: \`.php-cs-fixer.cache\`.

## Issues phpstan surfaced (and fixes)

**1. Missing value types on array properties/returns** (8 errors)

Added \`@var array<K, V>\` on all static rule tables, caches, and data-provider return types.

**2. \`preg_replace\` can return null** (5 errors)

PHP's \`preg_replace\` returns \`string|null\` — \`null\` on regex engine error. We control all patterns so null is effectively impossible in practice, but the type system correctly flags it. Fall back to the input string via \`?? \$string\` at all three call sites:

\`\`\`php
- self::\$pluralCache[\$string] = preg_replace(\$pattern, \$result, \$string);
+ self::\$pluralCache[\$string] = preg_replace(\$pattern, \$result, \$string) ?? \$string;
\`\`\`

## Issues cs-fixer surfaced (and fixes)
- Double-quoted literals with regex backreferences (\`"\$1zes"\`) converted to single-quoted (\`'\$1zes'\`). PHP doesn't interpolate \`\$1\` since a digit can't start an identifier, so behavior is identical; single-quoted is idiomatic for non-interpolated strings.
- One whitespace fix around a fat arrow.

## Test plan
- [x] 117 tests / 118 assertions pass on PHP 8.1 and 8.3.
- [x] phpstan level 8: **No errors**.
- [x] cs-fixer dry-run: clean.
- [ ] CI green on PHP 8.1–8.4 + new phpstan/cs-fixer steps on 8.3.

## Deferred
Roadmap §7 also calls for \`infection\` (mutation testing) and \`phpbench\` (benchmarks). Keeping those out of this PR to avoid ballooning scope — can land as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)